### PR TITLE
multiple segment control instances fix

### DIFF
--- a/SegmentedControl/SegmentControlViewSample/FilterControl.cs
+++ b/SegmentedControl/SegmentControlViewSample/FilterControl.cs
@@ -6,62 +6,86 @@ namespace SegmentControlViewSample
 {
 	public class FilterControl : View
 	{
-		public event EventHandler SelectedIndexChanged;
+    public event EventHandler SelectedIndexChanged;
 
-		public static readonly BindableProperty ItemsProperty =
-			BindableProperty.Create<FilterControl, List<string>>
-		(p => p.Items, new List<string>());
+    public static BindableProperty ItemsSourceProperty = BindableProperty.Create<FilterControl, IEnumerable<string>> (x => x.ItemsSource, default (IEnumerable<string>), BindingMode.OneWay, null, OnItemsSourceChanged);
 
-		public List<string> Items {
-			get {
-				return GetValue (ItemsProperty) as List<string>;
-			}
-			set { 
-				SetValue (ItemsProperty, value);
-			}
-		}
+    public List<string> Items
+    {
+      get
+      {
+        return ItemsAsObject;
+      }
+    }
 
-		public static readonly BindableProperty SelectedIndexProperty =
-			BindableProperty.Create<FilterControl, int>
-		(p => p.SelectedIndex, 0,BindingMode.TwoWay);
+    public List<string> ItemsAsObject = new List<string> ();
 
-		public int SelectedIndex {
-			get {
-				return (int)GetValue (SelectedIndexProperty);
-			}
-			set { 
-				SetValue (SelectedIndexProperty, value);
-			}
-		}
+    public IEnumerable<string> ItemsSource
+    {
+      get { return (IEnumerable<string>)GetValue (ItemsSourceProperty); }
+      set { SetValue (ItemsSourceProperty, value); }
+    }
 
-		public void OnSelectedIndexChanged(int newValue)
-		{
-			var args = new IndexChangedEventArgs () {
-				NewValue = newValue,
-				OldValue = SelectedIndex
-			};
+    private static void OnItemsSourceChanged (BindableObject bindableobject, IEnumerable<string> oldvalue, IEnumerable<string> newvalue)
+    {
+      var filtercontrol = bindableobject as FilterControl;
+      if (filtercontrol == null) return;
+      filtercontrol.Items.Clear ();
+      filtercontrol.ItemsAsObject.Clear ();      //This is the bound List with the Objects
+      if (newvalue != null)
+      {
+        foreach (var item in newvalue)
+        {
+          filtercontrol.ItemsAsObject.Add (item);
+          filtercontrol.Items.Add (item.ToString ());
+        }
+      }
+    }
 
-			SelectedIndex = newValue;
+    public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create<FilterControl, int> (p => p.SelectedIndex, 0, BindingMode.TwoWay);
 
-			if (SelectedIndexChanged != null) 
-			{				
-				SelectedIndexChanged (this, args);
-			}
-		}
+    public int SelectedIndex
+    {
+      get
+      {
+        return (int)GetValue (SelectedIndexProperty);
+      }
+      set
+      {
+        SetValue (SelectedIndexProperty, value);
+      }
+    }
 
-		public static readonly BindableProperty TintColorProperty =
-			BindableProperty.Create<FilterControl, Color>
-		(p => p.TintColor, Color.Default,BindingMode.TwoWay);
+    public void OnSelectedIndexChanged (int newValue)
+    {
+      var args = new IndexChangedEventArgs ()
+      {
+        NewValue = newValue,
+        OldValue = SelectedIndex
+      };
 
-		public Color TintColor {
-			get {
-				return (Color)GetValue (TintColorProperty);
-			}
-			set { 
-				SetValue (TintColorProperty, value);
-			}
-		}
-	
-	}
+      SelectedIndex = newValue;
+
+      if (SelectedIndexChanged != null)
+      {
+        SelectedIndexChanged (this, args);
+      }
+    }
+
+    public static readonly BindableProperty TintColorProperty =
+      BindableProperty.Create<FilterControl, Color>
+    (p => p.TintColor, Color.Default, BindingMode.TwoWay);
+
+    public Color TintColor
+    {
+      get
+      {
+        return (Color)GetValue (TintColorProperty);
+      }
+      set
+      {
+        SetValue (TintColorProperty, value);
+      }
+    }
+  }
 }
-

--- a/SegmentedControl/SegmentControlViewSample/MainView.xaml.cs
+++ b/SegmentedControl/SegmentControlViewSample/MainView.xaml.cs
@@ -16,7 +16,7 @@ namespace SegmentControlViewSample
 
 			var items = new List<string> (){ "All", "New", "Old" };
 
-			Filter.Items = items;
+			Filter.ItemsSource = items;
 		}
 
 		public class ViewModel : INotifyPropertyChanged

--- a/SegmentedControl/iOS/FilterControlRenderer.cs
+++ b/SegmentedControl/iOS/FilterControlRenderer.cs
@@ -58,7 +58,7 @@ namespace SegmentControlViewSample.iOS
 				}
 			}
 
-			if (e.PropertyName == FilterControl.ItemsProperty.PropertyName) 
+			if (e.PropertyName == FilterControl.ItemsSourceProperty.PropertyName) 
 			{
 				UpdateSegments ();
 			}


### PR DESCRIPTION
BUG: When multiple instances on the page, all instances seem to share the Items. The list appears to grow with each new instance of the control.
FIX: Changes the bindable property from Items to ItemsSource, both of which consume the same List<string>.
